### PR TITLE
Persistent logging

### DIFF
--- a/artwork_uploader.py
+++ b/artwork_uploader.py
@@ -43,11 +43,14 @@ from core.constants import (
     GITHUB_REPO,
     DEFAULT_WEB_PORT,
     DEFAULT_WEB_HOST,
+    DEFAULT_LOG_PATH,
     SCHEDULER_CHECK_INTERVAL,
     UPDATE_CHECK_INTERVAL,
     MIN_PYTHON_MAJOR,
     MIN_PYTHON_MINOR,
-    VALID_FILENAME_PATTERN
+    VALID_FILENAME_PATTERN,
+    URL_SOURCE_MAP,
+    URL_TYPE_MAP
 )
 from core.enums import InstanceMode, NotificationEvent, StatusColor, RunType, RunTrigger, RunOutcome
 from services import (
@@ -144,6 +147,8 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
         return
 
     start_time = time.time()
+
+    log_to_file(display_filename)
     update_log(instance, f"🎬 Bulk process started for '{display_filename}'")
 
     try:
@@ -191,10 +196,17 @@ def parse_bulk_file_from_cli(instance: Instance, file_path):
 
     finally:
         RunHistory().add_run(
-            RunType.BULK.value, display_filename, started_at, datetime.now(timezone.utc).isoformat(),
-            RunTrigger.CLI.value, outcome,
-            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
-            tally.locked_counter[0], tally.errors(errors)
+            run_type=RunType.BULK.value,
+            label=display_filename,
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=RunTrigger.CLI.value,
+            outcome=outcome,
+            assets_processed=tally.assets_processed[0],
+            success_count=tally.success_counter[0],
+            cached_count=tally.cached_counter[0],
+            locked_count=tally.locked_counter[0],
+            error_count=tally.errors(errors)
         )
 
 # ---------------------- GUI FUNCTIONS ----------------------
@@ -250,6 +262,7 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         # Process the URL and options passed from the GUI or website
         parsed_line = parse_url_and_options(url)
         label = parsed_line.url
+        log_to_file(label)
         update_status(instance, f"Scraping URL '{parsed_line.url}'", color=StatusColor.INFO.value, sticky=True, spinner=True)
 
         title, author = scrape_and_upload(
@@ -274,10 +287,17 @@ def process_scrape_url_from_web(instance: Instance, url: str) -> None:
         # makes the browser reload the history table, so a record written afterwards would
         # miss its own refresh and only appear the next time somebody opened the tab.
         RunHistory().add_run(
-            RunType.SCRAPE.value, label, started_at, datetime.now(timezone.utc).isoformat(),
-            RunTrigger.MANUAL.value, outcome,
-            tally.assets_processed[0], tally.success_counter[0], tally.cached_counter[0],
-            tally.locked_counter[0], tally.errors()
+            run_type=RunType.SCRAPE.value,
+            label=label,
+            started_at=started_at,
+            ended_at=datetime.now(timezone.utc).isoformat(),
+            trigger=RunTrigger.MANUAL.value,
+            outcome=outcome,
+            assets_processed=tally.assets_processed[0],
+            success_count=tally.success_counter[0],
+            cached_count=tally.cached_counter[0],
+            locked_count=tally.locked_counter[0],
+            error_count=tally.errors()
         )
         globals.scrapes_running -= 1
         if globals.scrapes_running <= 0:
@@ -303,6 +323,8 @@ def run_bulk_import_scrape_in_thread(
 
     # Loop through the import file and build a list of URLs and options
     # Ignoring any lines containing comments using # or //
+    if filename:
+        log_to_file(filename)
     update_log(instance, f"🎬 Bulk process started for '{filename}'")
 
     for n, line in enumerate(bulk_import_list, 1):
@@ -376,6 +398,7 @@ def process_bulk_import_from_ui(
     # collide repeatedly; the caller (a schedule or the user) simply tries again later.
     if not globals.bulk_import_lock.acquire(blocking=False):
         message = f"⚠️ Bulk import of '{display_filename}' refused - another bulk import is already running"
+        log_to_file(display_filename)
         update_log(instance, message)
         update_status(instance, "Bulk import refused: another bulk import is already running", color=StatusColor.WARNING.value)
         if schedule_id:
@@ -844,6 +867,30 @@ def sort_key(item):
     """Sort key for artwork items - uses UtilityService."""
     return UtilityService.sort_key(item)
 
+def log_to_file(label: str):
+    if globals.log_to_file:
+        debug_me(f"Logging is already active for another run")
+        return
+    if ".txt" in label:
+        log_label = f"bulk_{label.split(".txt")[0]}"
+    elif "https" in label:
+        clean_url = label.replace("https://", "").strip()
+        parts = [p for p in clean_url.split("/") if p]
+        if len(parts) >= 3:
+            domain, asset_type, id = parts[0], parts[1], parts[2]
+            source = URL_SOURCE_MAP.get(domain, "unknown_source")
+            type = URL_TYPE_MAP.get(asset_type, "Unknown_type")
+            url_type = type.get("label", "unknown_url_type")
+            log_label = f"{source}_{url_type}_{id}"
+    else:
+        log_label = label
+
+    log_label = log_label.lower()
+    timestamp = datetime.now()
+    log_filename = f"{timestamp.strftime('%Y-%m-%d_%H-%M-%S')}_{log_label}"
+    globals.log_to_file = os.path.join(DEFAULT_LOG_PATH, f"{log_filename}.log")
+    debug_me(f"Setting log file for this run to '{globals.log_to_file}'")
+
 # Autoupdate functions
 
 def get_latest_version():
@@ -906,6 +953,7 @@ def process_bulk_file_on_schedule(instance: Instance, filename, schedule_id):
             with open(bulk_import_file, "r", encoding="utf-8") as file:
                 content = file.read()
             if content:
+                log_to_file(filename)
                 update_log(instance, f"🕘 Scheduled bulk import started for '{filename}'")
                 debug_me(f"Scheduled import started for instance {instance.id} mode {instance.mode}")
                 send_notification(instance, f"🕘 Scheduled bulk import started for '{filename}'", event=NotificationEvent.RUN_STARTED.value)

--- a/core/constants.py
+++ b/core/constants.py
@@ -24,6 +24,7 @@ ASSET_INDEX_PATH = "config/asset_index.db"
 DEFAULT_BULK_IMPORTS_DIR = "bulk_imports"
 DEFAULT_BULK_IMPORT_FILE = "bulk_import.txt"
 RUN_HISTORY_PATH = "config/run_history.json"
+DEFAULT_LOG_PATH = "logs"
 
 # Run history retention (whichever limit is hit first prunes the record).
 # The entry cap is per run type, so frequent webhook imports can't crowd out bulk runs.

--- a/core/globals.py
+++ b/core/globals.py
@@ -20,6 +20,7 @@ scrapes_running: int = 0      # How many scrapes are in flight; the flag clears 
 scrape_type: Literal['scrape', 'bulk', 'upload', 'stopped'] = 'stopped'
 main_bar: dict = {}
 bulk_bar: dict = {}
+log_to_file: str = None
 
 # Single-flight guard for bulk imports (scheduled or manual). A second bulk import that starts
 # while one is already running is refused rather than queued - see process_bulk_import_from_ui.

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./bulk_imports:/artwork-uploader/bulk_imports:rw
       - ./config:/artwork-uploader/config:rw
+      - ./logs:/artwork-uploader/logs:rw
       - <HOST_PATH_TO_KOMETA_ASSET_DIRECTORY>:/assets:rw
       - <HOST_TEMP_PATH>:/Temp/assets:/temp:rw
     environment:

--- a/scrapers/mediux_scraper.py
+++ b/scrapers/mediux_scraper.py
@@ -235,8 +235,9 @@ class MediuxScraper:
             
             show_id_backdrop_data = poster.get("show_id_backdrop", None)
             is_show_backdrop = show_id_backdrop_data is not None
-            
-            season_id_data = poster.get("season_id", None)
+
+            tvdb_season_id = poster.get("tvdb_season_id", None)
+            season_id_data = poster.get("season_id", None) or tvdb_season_id
             is_season_cover = season_id_data is not None
             season_id = season_id_data.get("id", None) if season_id_data else None
             
@@ -282,10 +283,15 @@ class MediuxScraper:
 
                 elif is_season_cover: # This is a season cover
                     file_type = FileType.SEASON_COVER.value
+                    episode = "Cover"
                     if season_id in show_map["seasons"]:
                         season = show_map["seasons"][season_id]
-                        episode = "Cover"
                         self.callbacks.debug(f"Detected season cover for S{season:02}")
+                    elif tvdb_season_id: # Fallback for MediUX sets that use TVDb metadata
+                        poster_title = poster.get("title", None)
+                        if poster_title and "Season" in poster_title:
+                            season = int(poster_title.split("Season")[-1].strip())
+                            self.callbacks.debug(f"Detected season cover for {season} S{season:02}")
                     else:
                         self.callbacks.debug(f"⏩ Skipping season cover - incorrect season metadata")
                         self.callbacks.log(f"⚠️ {show_name} ({year}) • {self.author} | Skipping season cover - incorrect season metadata")

--- a/services/run_history.py
+++ b/services/run_history.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 from core.enums import RunType, RunTrigger
 from core import globals
 
-from core.constants import RUN_HISTORY_PATH, RUN_HISTORY_MAX_ENTRIES, RUN_HISTORY_MAX_AGE_DAYS
+from core.constants import RUN_HISTORY_PATH, RUN_HISTORY_MAX_ENTRIES, RUN_HISTORY_MAX_AGE_DAYS, DEFAULT_LOG_PATH
 
 # A new RunHistory() is created per call rather than shared, so the read-modify-write in
 # add_run needs a lock keyed by file path (not an instance lock) to stop two runs finishing
@@ -81,8 +81,10 @@ class RunHistory:
                 pass  # nothing to tidy up, or the same problem that stopped the write
 
     def _prune(self, runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        pruned_runs = []
         if self.max_age_days:
             cutoff = (datetime.now(timezone.utc) - timedelta(days=self.max_age_days)).isoformat()
+            pruned_runs = [run for run in runs if run.get("started_at", "") < cutoff]
             runs = [run for run in runs if run.get("started_at", "") >= cutoff]
         if self.max_entries:
             # The count cap is per run type. A busy library can take dozens of webhook
@@ -93,10 +95,23 @@ class RunHistory:
             for run in reversed(runs):
                 run_type = run.get("run_type", RunType.BULK.value)
                 if kept_per_type[run_type] >= self.max_entries:
+                    pruned_runs.append(run)
                     continue
                 kept_per_type[run_type] += 1
                 kept.append(run)
             runs = list(reversed(kept))
+        # Delete the log files for the pruned runs
+        for run in pruned_runs:
+            log_file = run.get("log_file", "")
+            if log_file:
+                full_path = os.path.join(DEFAULT_LOG_PATH, log_file)
+                try:
+                    os.remove(full_path)
+                    debug_me(f"Deleted log file '{log_file}'")
+                except Exception as e:
+                    from utils.notifications import debug_me
+                    debug_me(f"Unable to remove log file '{log_file}': {str(e)}")
+                    pass
         return runs
 
     def add_run(
@@ -132,8 +147,10 @@ class RunHistory:
                 "cached_count": cached_count,
                 "locked_count": locked_count,
                 "error_count": error_count,
+                "log_file": os.path.basename(globals.log_to_file) if globals.log_to_file else ""
             })
             self._save(self._prune(runs))
+        globals.log_to_file = None # Stop persistent logging after a run is recorded
         if job_id and globals.scheduler_service:
             job_meta = globals.scheduler_service.schedule_meta.get(job_id)
             if job_meta:

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -8,8 +8,7 @@ authoritative TMDb resolution, artwork-ID skips, locked-artwork skips, Kometa mo
 code a normal scrape uses, so the webhook inherits all of it without re-implementing any of it.
 """
 
-import threading
-import time
+import threading, time, re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import FrozenSet, List, Optional, Union
@@ -39,6 +38,10 @@ def _debug(message: str) -> None:
     from utils.notifications import debug_me
     debug_me(message, "WebhookService")
 
+def _clean_title(title: str) -> str:
+    """Removes year in parenthesis from title"""
+    return re.sub(r'\s*\(\d{4}\)$', '', title.strip())
+
 
 @dataclass(frozen=True)
 class WebhookEvent:
@@ -52,7 +55,9 @@ class WebhookEvent:
     source: str                    # "radarr" or "sonarr"
 
     def label(self) -> str:
-        return f"{self.title} ({self.year})" if self.year else self.title
+        # Remove the year from the title if the title contains it to avoid duplicating it
+        clean_title = _clean_title(self.title)
+        return f"{clean_title} ({self.year})" if self.year else self.title # Keeps the year in the title if the year is not present in the event
 
 
 def _int_or_none(value) -> Optional[int]:
@@ -153,6 +158,10 @@ class WebhookService:
         from processors.upload_processor import UploadProcessor
         outcome = RunOutcome.FAILED.value
         try:
+            from artwork_uploader import log_to_file
+            clean_title = _clean_title(event.title)
+            log_Label = f"webhook_{clean_title}_{event.year}" if event.year else f"webhook_{_clean_title(clean_title)}"
+            log_to_file(log_Label)
             if artwork is None:
                 artwork = self._collect_artwork(event)
                 if not artwork:
@@ -223,11 +232,17 @@ class WebhookService:
         """Record the run and let the next event for this title through."""
         try:
             RunHistory().add_run(
-                RunType.WEBHOOK.value, event.label(), started_at,
-                datetime.now(timezone.utc).isoformat(),
-                _TRIGGER_BY_SOURCE.get(event.source, event.source), outcome,
-                tally.assets_processed[0], tally.success_counter[0], 0,
-                tally.locked_counter[0], tally.failed_counter[0],
+                run_type=RunType.WEBHOOK.value,
+                label=event.label(),
+                started_at=started_at,
+                ended_at=datetime.now(timezone.utc).isoformat(),
+                trigger=_TRIGGER_BY_SOURCE.get(event.source, event.source),
+                outcome=outcome,
+                assets_processed=tally.assets_processed[0],
+                success_count=tally.success_counter[0],
+                cached_count=0,
+                locked_count=tally.locked_counter[0],
+                error_count=tally.failed_counter[0]
             )
             # Nothing else tells an open History tab that this happened. A scrape and a
             # bulk import both end with a scrape_state broadcast the browser reacts to;

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1795,13 +1795,14 @@ function loadRunHistory() {
             const triggerLabel = RUN_HISTORY_TRIGGER_LABELS[run.trigger] || "unknown";
             const typeIcon = RUN_HISTORY_TYPE_ICONS[run.run_type] || "question-circle";
             const typeLabel = RUN_HISTORY_TYPE_LABELS[run.run_type] || "unknown";
+            const logFileName = run.log_file
 
             const cells = [
                 formatDateTime(run.started_at),
                 `<i class="bi bi-${typeIcon}" title="${typeLabel}"></i>`, // Run Type
                 run.label,
                 `<i class="bi bi-${triggerIcon}" title="${triggerLabel}"></i>`, // Run Trigger
-                `<i class="bi bi-${outcome.icon}" title="${outcome.text}"></i>`, // Run Outcome
+                `<i class="bi bi-${outcome.icon} cursor-pointer" style="cursor: pointer;" title="${outcome.text}" onclick="showLogsforRun('${logFileName}')"></i>`, // Run Outcome
                 `<span class="text-monospace">${run.assets_processed}</span>`,
                 `<span class="text-monospace">${run.success_count}</span>`,
                 `<span class="text-monospace">${run.cached_count}</span>`,
@@ -1825,6 +1826,40 @@ function loadRunHistory() {
             body.appendChild(row);
         });
     });
+}
+
+function showLogsforRun(logFileName) {
+    if (!logFileName) return;
+
+    socket.emit("get_log_file", { instance_id: instanceId, log_file_name: logFileName });
+
+    socket.once("get_log_file", data => {
+        if (validResponse(data)) {
+            if (data.success) {
+                const logText = data.contents;
+                const modalEl = document.getElementById("run_log_modal");
+                const contentEl = document.getElementById("run_log_content");
+                const modalTitleEl = document.getElementById("runLogModalLabel");
+
+                // Update modal header title & content
+                if (modalTitleEl) {
+                    modalTitleEl.innerHTML = `<i class="bi bi-file-earmark-text"></i>&ensp;<span class="text-monospace small">${logFileName}</span>`;
+                }
+                
+                if (contentEl) {
+                    contentEl.textContent = logText;
+                }
+
+                // Show modal safely
+                const logModal = bootstrap.Modal.getOrCreateInstance(modalEl);
+                logModal.show();
+
+            } else {
+                console.warn("Unable to display log file contents")
+            }
+        }
+    })
+
 }
 
 function saveBulkImport(filename, nowLoad = null) {

--- a/templates/web_interface.html
+++ b/templates/web_interface.html
@@ -1406,6 +1406,23 @@
     <script src="/static/dark_mode.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
 
+    <!-- Run History Log Viewer Modal -->
+    <div class="modal fade" id="run_log_modal" tabindex="-1" aria-labelledby="runLogModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="runLogModalLabel">
+                        <i class="bi bi-file-earmark-text"></i>&ensp;Execution Log
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body bg-dark text-light p-3">
+                    <pre id="run_log_content" class="text-monospace mb-0" style="white-space: pre-wrap; font-size: 0.825rem; max-height: 60vh; overflow-y: auto;"></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Folder Browser Modal -->
     <div class="modal fade" id="folderBrowserModal" tabindex="-1" aria-labelledby="folderBrowserModalLabel">
         <div class="modal-dialog modal-dialog-scrollable">

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from core import globals
 from pprint import pprint
 from models.instance import Instance
-from core.constants import BOOTSTRAP_COLORS, ANSI_RESET, ANSI_BOLD
+from core.constants import BOOTSTRAP_COLORS, ANSI_RESET, ANSI_BOLD, DEFAULT_LOG_PATH
 from services.notify_service import NotifyService
 
 # For backwards compatibility
@@ -99,8 +99,21 @@ def update_log(instance: Instance, update_text: str, broadcast: bool = False) ->
     """
     try:
         timestamp = datetime.now().strftime("%H:%M:%S.%f")[:-3]
+        log_message = f"{ANSI_BOLD}{BOOTSTRAP_COLORS.get('info').get('ansi')}[{timestamp}]{ANSI_RESET} {update_text}"
+        log_file_message = f"[{timestamp}] {update_text}\n"
         with print_lock:
-            print(f"{ANSI_BOLD}{BOOTSTRAP_COLORS.get('info').get('ansi')}[{timestamp}]{ANSI_RESET} {update_text}")
+            print(log_message)
+        if globals.log_to_file:
+            try:
+                if not os.path.exists(globals.log_to_file):
+                    os.makedirs(DEFAULT_LOG_PATH, exist_ok=True)
+                    with open(globals.log_to_file, mode="xt", encoding="utf-8") as log_file:
+                        log_file.write("-"*40 + f" {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} " + "-"*40 + "\n")
+                with open(globals.log_to_file, mode="at", buffering=1, encoding="utf-8") as log_file:
+                    log_file.write(f"{log_file_message}")
+            except Exception as e:
+                debug_me(f"Unable to initialize log file {globals.log_to_file}: {str(e)}")
+                pass
         if instance.mode == "web":
             if not instance.broadcast and broadcast:
                 instance.broadcast = broadcast

--- a/web_routes.py
+++ b/web_routes.py
@@ -28,7 +28,7 @@ from processors.media_metadata import parse_title
 from utils.notifications import update_log, update_status, notify_web, debug_me
 from services import UtilityService, AuthenticationService, RunHistory
 from services.webhook_service import parse_event
-from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER, URL_SOURCE_MAP, URL_TYPE_MAP
+from core.constants import UPLOAD_CHUNK_SIZE, UPLOAD_CHUNK_TIMEOUT, WEBHOOK_TOKEN_HEADER, URL_SOURCE_MAP, URL_TYPE_MAP, DEFAULT_LOG_PATH
 
 def login_required(f):
     """Decorator to require authentication for routes."""
@@ -360,6 +360,31 @@ def setup_socket_handlers(
             debug_me(f"Error loading bulk import file list: {e}")
         notify_web(instance, "load_bulk_filelist", {"bulk_files": bulk_files})
 
+    @globals.web_socket.on("get_log_file")
+    def get_log_file(data):
+        """Get the contents of a log file and send them back to the frontend"""
+        instance = Instance(data.get("instance_id"), "web")
+        log_file_name = data.get("log_file_name")
+        full_path = os.path.join(DEFAULT_LOG_PATH, log_file_name)
+        log_file_contents = ""
+
+        try:
+            with open(full_path, "r", encoding="utf-8") as log_file:
+                log_file_contents = log_file.read()
+            debug_me(f"Successfully obtained contents of log file '{log_file_name}'")
+        except Exception as e:
+            debug_me(f"Unable to read contents of log file '{log_file_name}': {str(e)}")
+
+        notify_web(
+            instance=instance,
+            event="get_log_file",
+            data_to_include={
+                "success": True if log_file_contents else False,
+                "contents": log_file_contents
+            },
+            silent=True
+        )
+
     @globals.web_socket.on("load_run_history")
     def load_run_history(data):
         """Load recent run history, optionally narrowed to one run type."""
@@ -386,7 +411,15 @@ def setup_socket_handlers(
                 else:
                     run["label"] = f"<i class='bi bi-x-octagon text-danger' title='{label}'>&nbsp;Error parsing URL</i>"
 
-        notify_web(instance, "load_run_history", {"runs": runs, "run_type": run_type or "all"})
+        notify_web(
+            instance=instance,
+            event="load_run_history",
+            data_to_include={
+                "runs": runs,
+                "run_type": run_type or "all"
+            },
+            silent=True
+        )
 
     @globals.web_socket.on("load_bulk_import")
     def load_bulk_import(data):


### PR DESCRIPTION
Every run of every type (CLI, scrape, bulk, webhook) gets a persistent log file that can be viewed in the web UI by clicking on the Outcome icon of the Run History tab