### PR TITLE
Keep each run's log file with the run when two overlap

### DIFF
--- a/core/globals.py
+++ b/core/globals.py
@@ -20,7 +20,12 @@ scrapes_running: int = 0      # How many scrapes are in flight; the flag clears 
 scrape_type: Literal['scrape', 'bulk', 'upload', 'stopped'] = 'stopped'
 main_bar: dict = {}
 bulk_bar: dict = {}
-log_to_file: str = None
+# The log file for the run on the current thread, set by utils.notifications.log_to_file and
+# cleared when RunHistory records the run. A run and everything it logs happen on one thread,
+# so the thread is what keeps one run's lines apart from another's when two overlap. One
+# shared path could not: a webhook import finishing mid bulk import would record the bulk
+# run's file as its own and switch that run's logging off underneath it.
+run_log = threading.local()
 upload_run_metadata = {}
 
 # Single-flight guard for bulk imports (scheduled or manual). A second bulk import that starts

--- a/services/run_history.py
+++ b/services/run_history.py
@@ -147,6 +147,10 @@ class RunHistory:
 
         `label` is what the run was about: the bulk file name, the scraped URL, the
         uploaded ZIP name, or the title the webhook imported."""
+        # The file this thread's run has been logging to. It is read here rather than passed
+        # in so every path that records a run picks it up, and it is per thread so a run
+        # finishing while another is still going records its own file, not the other's.
+        log_file = getattr(globals.run_log, "path", None)
         with _write_locks[os.path.abspath(self.path)]:
             runs = self._load()
             runs.append({
@@ -161,10 +165,10 @@ class RunHistory:
                 "cached_count": cached_count,
                 "locked_count": locked_count,
                 "error_count": error_count,
-                "log_file": os.path.basename(globals.log_to_file) if globals.log_to_file else ""
+                "log_file": os.path.basename(log_file) if log_file else ""
             })
             self._save(self._prune(runs))
-        globals.log_to_file = None # Stop persistent logging after a run is recorded
+        globals.run_log.path = None # This run is recorded, so its thread stops logging to the file
         if job_id and globals.scheduler_service:
             job_meta = globals.scheduler_service.schedule_meta.get(job_id)
             if job_meta:

--- a/services/webhook_service.py
+++ b/services/webhook_service.py
@@ -152,16 +152,22 @@ class WebhookService:
             self._inflight.discard(key)
 
     def _attempt(self, event: WebhookEvent, key, started_at: str, tally: ProcessingCallbacks,
-                 attempt: int = 0, artwork: Optional[List[dict]] = None) -> None:
+                 attempt: int = 0, artwork: Optional[List[dict]] = None,
+                 log_file: Optional[str] = None) -> None:
         # UploadProcessor pulls in the processors -> plex chain; import it here so the services
         # package does not drag that in at start-up (mirrors the app's own lazy-import pattern).
         from processors.upload_processor import UploadProcessor
         outcome = RunOutcome.FAILED.value
         try:
-            from utils.notifications import log_to_file
-            clean_title = _clean_title(event.title)
-            log_Label = f"webhook_{clean_title}_{event.year}" if event.year else f"webhook_{_clean_title(clean_title)}"
-            log_to_file(log_Label)
+            from utils.notifications import log_to_file, resume_log_file
+            if log_file:
+                # A retry runs on a fresh Timer thread. Keep the whole ladder in the file the
+                # first attempt opened, the same way it keeps one history record.
+                resume_log_file(log_file)
+            else:
+                clean_title = _clean_title(event.title)
+                log_Label = f"webhook_{clean_title}_{event.year}" if event.year else f"webhook_{_clean_title(clean_title)}"
+                log_file = log_to_file(log_Label)
             if artwork is None:
                 artwork = self._collect_artwork(event)
                 if not artwork:
@@ -206,7 +212,7 @@ class WebhookService:
                 delay = WEBHOOK_RETRY_DELAYS[attempt]
                 _debug(f"{event.label()} not in Plex yet, retrying in {delay}s")
                 timer = threading.Timer(
-                    delay, self._attempt, args=(event, key, started_at, tally, attempt + 1, pending)
+                    delay, self._attempt, args=(event, key, started_at, tally, attempt + 1, pending, log_file)
                 )
                 timer.daemon = True
                 timer.start()

--- a/static/web_interface.js
+++ b/static/web_interface.js
@@ -1991,7 +1991,7 @@ let logFilterToggles = {
 }
 
 function showLogsforRun(logFileName, runLabel) {
-    if (logFileName === "undefined") {
+    if (!logFileName || logFileName === "undefined") {
         updateStatus(`No associated log file for ${runLabel}`, "warning", false, false, "exclamation-triangle")
         return;
     }

--- a/tests/test_run_log_file.py
+++ b/tests/test_run_log_file.py
@@ -1,0 +1,128 @@
+"""
+The per-run log file follows the run, not the process.
+
+Every run writes its own file under the logs directory and its history record points at
+it. Runs overlap all the time on a busy server: a Radarr or Sonarr import lands while a
+scheduled bulk import is hours from finishing. Each run keeps its own file through that,
+and a run that continues on another thread (a webhook retry, a chunked upload) carries its
+file across the hop.
+"""
+
+import os
+import threading
+
+import pytest
+
+import core.globals as globals
+import services.run_history as run_history_module
+import utils.notifications as notifications
+from models.instance import Instance
+from services.run_history import RunHistory
+from utils.notifications import current_log_file, log_to_file, resume_log_file, update_log
+
+
+@pytest.fixture
+def log_dir(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(notifications, "DEFAULT_LOG_PATH", str(log_dir))
+    monkeypatch.setattr(run_history_module, "DEFAULT_LOG_PATH", str(log_dir))
+    return log_dir
+
+
+@pytest.fixture
+def history(tmp_path):
+    return RunHistory(str(tmp_path / "run_history.json"))
+
+
+@pytest.fixture(autouse=True)
+def no_log_on_the_test_thread():
+    globals.run_log.path = None
+    yield
+    globals.run_log.path = None
+
+
+def _record(history, run_type, label):
+    history.add_run(
+        run_type=run_type,
+        label=label,
+        started_at="2026-09-05T00:00:00+00:00",
+        ended_at="2026-09-05T00:01:00+00:00",
+        trigger="manual",
+        outcome="success",
+    )
+
+
+def _on_a_thread(target):
+    """Run `target` to completion on its own thread, the way a webhook or a schedule does."""
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+
+
+@pytest.mark.unit
+def test_a_run_finishing_mid_way_through_another_leaves_that_run_its_log(log_dir, history):
+    """The bug this guards against: a webhook import that finished during a bulk import used
+    to record the bulk run's file as its own and switch the bulk run's logging off, so the
+    long run, the one worth reading, ended with no log at all."""
+    bulk = Instance(mode="cli")
+    bulk_log = log_to_file("bulk_import_full.txt")
+    update_log(bulk, "bulk line one")
+
+    def webhook_import():
+        webhook_log = log_to_file("webhook_Dune_2021")
+        assert webhook_log != bulk_log
+        update_log(Instance(mode="cli"), "webhook line")
+        _record(history, "webhook", "Dune (2021)")
+        assert current_log_file() is None, "recording the run ends its own logging"
+
+    _on_a_thread(webhook_import)
+
+    assert current_log_file() == bulk_log, "the other run's finish must not touch this one"
+    update_log(bulk, "bulk line two")
+    _record(history, "bulk", "bulk_import_full.txt")
+
+    runs = {run["run_type"]: run for run in history.get_runs()}
+    assert runs["bulk"]["log_file"] == os.path.basename(bulk_log)
+    assert runs["webhook"]["log_file"] != runs["bulk"]["log_file"]
+    assert runs["webhook"]["log_file"] != ""
+
+    bulk_text = (log_dir / runs["bulk"]["log_file"]).read_text(encoding="utf-8")
+    assert "bulk line one" in bulk_text and "bulk line two" in bulk_text
+    assert "webhook line" not in bulk_text
+    assert "webhook line" in (log_dir / runs["webhook"]["log_file"]).read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_a_run_keeps_the_file_it_opened_first(log_dir):
+    """A scheduled import asks for its log twice on the way in, once from the schedule and
+    once from the import itself. It gets one file."""
+    first = log_to_file("bulk_import_fast.txt")
+    second = log_to_file("bulk_import_fast.txt")
+    assert first == second
+    assert current_log_file() == first
+
+
+@pytest.mark.unit
+def test_resume_carries_a_run_onto_the_thread_that_continues_it(log_dir, history):
+    """A webhook retry and a later upload chunk each run on a fresh thread, which starts with
+    no log file. Resuming the path there keeps the whole run in one file."""
+    opened_on = log_to_file("webhook_Dune_2021")
+    update_log(Instance(mode="cli"), "first attempt")
+
+    def later_attempt():
+        assert current_log_file() is None, "a new thread starts outside any run"
+        resume_log_file(opened_on)
+        update_log(Instance(mode="cli"), "second attempt")
+        _record(history, "webhook", "Dune (2021)")
+
+    _on_a_thread(later_attempt)
+
+    assert history.get_runs()[0]["log_file"] == os.path.basename(opened_on)
+    text = (log_dir / os.path.basename(opened_on)).read_text(encoding="utf-8")
+    assert "first attempt" in text and "second attempt" in text
+
+
+@pytest.mark.unit
+def test_a_run_recorded_with_no_log_file_records_an_empty_name(history):
+    _record(history, "bulk", "bulk_import.txt")
+    assert history.get_runs()[0]["log_file"] == ""

--- a/tests/test_webhook_service.py
+++ b/tests/test_webhook_service.py
@@ -1,5 +1,6 @@
 """Unit tests for the Sonarr/Radarr import webhook (services/webhook_service.py)."""
 
+import os
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
@@ -312,6 +313,44 @@ def test_a_retry_does_not_record_a_run_of_its_own(monkeypatch, history):
                      attempt=0, artwork=[{"id": 1, "file_type": "movie_poster"}])
 
     assert history.get_runs() == []
+
+
+@pytest.mark.unit
+def test_a_retry_carries_the_log_file_the_first_attempt_opened(monkeypatch, history, tmp_path):
+    """Each attempt runs on its own Timer thread, and a thread starts with no log file. The
+    first attempt hands its file to the retry, and the retry records that file, so one import
+    is one log the way it is one history row."""
+    import utils.notifications as notifications
+    from core import globals as app_globals
+
+    monkeypatch.setattr(notifications, "DEFAULT_LOG_PATH", str(tmp_path / "logs"))
+    app_globals.run_log.path = None
+    scheduled = {}
+
+    class _FakeTimer:
+        def __init__(self, interval, function, args=()):
+            scheduled["args"] = args
+            self.daemon = False
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(webhook_service_module.threading, "Timer", _FakeTimer)
+    pending = _applying_service(monkeypatch, ["Poster not available on Plex"])
+    pending._attempt(_dune(), ("movie", 438631), _now(), _tally(),
+                     attempt=0, artwork=[{"id": 1, "file_type": "movie_poster"}])
+
+    log_file = scheduled["args"][-1]
+    assert log_file and log_file == notifications.current_log_file()
+    app_globals.run_log.path = None       # the retry lands on a fresh thread
+
+    applied = _applying_service(monkeypatch, ["✅ Poster uploaded"])
+    applied._attempt(*scheduled["args"])
+
+    runs = history.get_runs()
+    assert len(runs) == 1
+    assert runs[0]["log_file"] == os.path.basename(log_file)
+    assert notifications.current_log_file() is None
 
 
 @pytest.mark.unit

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -1,5 +1,6 @@
 import threading, inspect, os
 from datetime import datetime
+from typing import Optional
 from core import globals
 from pprint import pprint
 from models.instance import Instance
@@ -103,16 +104,17 @@ def update_log(instance: Instance, update_text: str, broadcast: bool = False) ->
         log_file_message = f"[{timestamp}] {update_text}\n"
         with print_lock:
             print(log_message)
-        if globals.log_to_file:
+        run_log_file = current_log_file()
+        if run_log_file:
             try:
-                if not os.path.exists(globals.log_to_file):
+                if not os.path.exists(run_log_file):
                     os.makedirs(DEFAULT_LOG_PATH, exist_ok=True)
-                    with open(globals.log_to_file, mode="xt", encoding="utf-8") as log_file:
+                    with open(run_log_file, mode="xt", encoding="utf-8") as log_file:
                         log_file.write("-"*40 + f" {datetime.now().strftime("%Y-%m-%d %H:%M:%S")} " + "-"*40 + "\n")
-                with open(globals.log_to_file, mode="at", buffering=1, encoding="utf-8") as log_file:
+                with open(run_log_file, mode="at", buffering=1, encoding="utf-8") as log_file:
                     log_file.write(f"{log_file_message}")
             except Exception as e:
-                debug_me(f"Unable to initialize log file {globals.log_to_file}: {str(e)}")
+                debug_me(f"Unable to initialize log file {run_log_file}: {str(e)}")
                 pass
         if instance.mode == "web":
             if not instance.broadcast and broadcast:
@@ -187,10 +189,28 @@ def send_notification(instance: Instance, message: str, event: str = None) -> No
         debug_me(f"🚨 Error sending notification: {str(e)}")
         update_log(instance, f"🚨 Error sending notification: {str(e)}")
 
-def log_to_file(label: str):
-    if globals.log_to_file:
-        debug_me(f"Logging is already active for another run")
-        return
+def current_log_file() -> Optional[str]:
+    """The log file the run on this thread is writing to, or None outside a run."""
+    return getattr(globals.run_log, "path", None)
+
+def resume_log_file(path: Optional[str]) -> None:
+    """
+    Carry a run's log file onto the thread that continues the run.
+
+    A run and its log normally share one thread. Two kinds of run continue on another: a
+    webhook's retry ladder, where every attempt is a new Timer thread, and a chunked ZIP
+    upload, where every chunk arrives on its own socket handler thread. They pass the path
+    across the hop and call this on the far side, so the whole run lands in one file.
+    """
+    globals.run_log.path = path or None
+
+def log_to_file(label: str) -> Optional[str]:
+    """Open a log file for the run on this thread, named from `label`, and return its path.
+    A run that already has one keeps it."""
+    current = current_log_file()
+    if current:
+        debug_me(f"Logging is already active for this run")
+        return current
     if ".txt" in label:
         log_label = f"bulk_{label.split(".txt")[0]}"
     elif "https" in label:
@@ -208,5 +228,6 @@ def log_to_file(label: str):
     log_label = log_label.lower()
     timestamp = datetime.now()
     log_filename = f"{timestamp.strftime('%Y-%m-%d_%H-%M-%S')}_{log_label}"
-    globals.log_to_file = os.path.join(DEFAULT_LOG_PATH, f"{log_filename}.log")
-    debug_me(f"Setting log file for this run to '{globals.log_to_file}'")
+    globals.run_log.path = os.path.join(DEFAULT_LOG_PATH, f"{log_filename}.log")
+    debug_me(f"Setting log file for this run to '{globals.run_log.path}'")
+    return globals.run_log.path

--- a/web_routes.py
+++ b/web_routes.py
@@ -27,7 +27,7 @@ from core.config import Config, normalize_notification_channels
 from core.enums import FileType, MediaType, ScraperSource, StatusColor, RunType, RunTrigger, RunOutcome, IntervalUnit, AuthType
 from core.__version__ import __version__
 from processors.media_metadata import parse_title
-from utils.notifications import update_log, update_status, notify_web, debug_me, log_to_file
+from utils.notifications import update_log, update_status, notify_web, debug_me, log_to_file, resume_log_file
 from services import UtilityService, AuthenticationService, RunHistory
 from services.webhook_service import parse_event
 from core.constants import (
@@ -1130,6 +1130,7 @@ def setup_socket_handlers(
             globals.main_bar["active"] = False
 
             if instance:
+                resume_log_file(globals.upload_run_metadata.get("log_file"))   # the watchdog fires on its own thread
                 update_log(instance, f"⚠️ {file_name} • Upload timed out after {UPLOAD_CHUNK_TIMEOUT} seconds (connection lost)")
                 update_status(instance, "Upload timed out", color=StatusColor.DANGER.value)
                 notify_web(instance, "scrape_state", {
@@ -1180,11 +1181,14 @@ def setup_socket_handlers(
             log_label = f"upload_{clean_file_name}"
             globals.upload_run_metadata["run_label"] = run_label
             globals.upload_run_metadata["start_time"] = run_start
-            log_to_file(log_label)
+            globals.upload_run_metadata["log_file"] = log_to_file(log_label)
 
             update_log(instance, f"📤 {file_name} • Upload initiated")
             debug_me(f"Uploading '{file_name}")
             notify_web(instance, "scrape_state", { "running": True, "type": globals.scrape_type })
+        else:
+            # Every chunk arrives on its own handler thread, so pick the run's log file back up
+            resume_log_file(globals.upload_run_metadata.get("log_file"))
 
         if globals.cancel_scrape:
             debug_me(f"File upload canceled by user")
@@ -1280,6 +1284,8 @@ def setup_socket_handlers(
         """Finalize the upload once all chunks are received."""
         instance = Instance(data.get("instance_id"), "web", broadcast=True)
         file_name = data.get("fileName")
+        # This handler runs on its own thread too, and the processing that follows records the run
+        resume_log_file(globals.upload_run_metadata.get("log_file"))
 
         notify_web(instance, "progress_bar", { "percent": 100, "message": f"{file_name} • Upload complete!", "bar_speed": "fast"} )
 


### PR DESCRIPTION
The per-run log from #124 keeps the current file in one global. A run that starts while another is still going returns early from `log_to_file` and writes into the first run's file. On finishing it records that file as its own and sets the global to `None`. The first run then logs nothing more and records no `log_file`. A Sonarr or Radarr import landing during a scheduled bulk import does exactly this, and deleting the webhook row afterwards deletes the bulk run's file.

The path is now a thread local. A run and everything it logs share one thread, so the call sites do not change. Two kinds of run continue on another thread and carry the path across. A webhook retry passes it through the `Timer` arguments. A chunked ZIP upload keeps it in `upload_run_metadata` and resumes it on each chunk, on completion and in the timeout watchdog.

The history format and the viewer do not change. A row with an empty `log_file` now gets the "no associated log file" notice instead of a failed load.

Tests: `tests/test_run_log_file.py` covers the overlap, same-thread reuse and the resume across a thread. `tests/test_webhook_service.py` gains a test that a retry records the file the first attempt opened.
